### PR TITLE
Remove defined-or operator

### DIFF
--- a/lib/JSON/Schema/Test/Acceptance.pm
+++ b/lib/JSON/Schema/Test/Acceptance.pm
@@ -75,8 +75,8 @@ sub acceptance {
   my ($self, $code, $options) = @_;
   my $tests = $self->_load_tests;
 
-  my $skip_tests = $options->{skip_tests} // {};
-  my $only_test = $options->{only_test} // undef;
+  my $skip_tests = defined $options->{skip_tests} ? $options->{skip_tests} : {};
+  my $only_test = $options->{only_test};
 
   $self->_run_tests($code, $tests, $skip_tests, $only_test);
 


### PR DESCRIPTION
The defined-or operator `//` was introduced in 5.010, but the heads of the files indicate you are targeting v5.006.
