### PR TITLE
Bump minimum perl requirement to 5.010

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,7 +10,7 @@ WriteMakefile(
     ABSTRACT_FROM    => 'lib/JSON/Schema/Test/Acceptance.pm',
     LICENSE          => 'mit',
     PL_FILES         => {},
-    MIN_PERL_VERSION => 5.006,
+    MIN_PERL_VERSION => 5.010,
     CONFIGURE_REQUIRES => {
         'ExtUtils::MakeMaker' => 0,
     },

--- a/lib/JSON/Schema/Test/Acceptance.pm
+++ b/lib/JSON/Schema/Test/Acceptance.pm
@@ -1,6 +1,6 @@
 package JSON::Schema::Test::Acceptance;
 
-use 5.006;
+use 5.010;
 use strict;
 use warnings;
 

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -1,5 +1,5 @@
 #!perl -T
-use 5.006;
+use 5.010;
 use strict;
 use warnings;
 use Test::More;

--- a/t/manifest.t
+++ b/t/manifest.t
@@ -1,5 +1,5 @@
 #!perl -T
-use 5.006;
+use 5.010;
 use strict;
 use warnings;
 use Test::More;

--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -1,5 +1,5 @@
 #!perl -T
-use 5.006;
+use 5.010;
 use strict;
 use warnings;
 use Test::More;

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,5 +1,5 @@
 #!perl -T
-use 5.006;
+use 5.010;
 use strict;
 use warnings;
 use Test::More;

--- a/xt/boilerplate.t
+++ b/xt/boilerplate.t
@@ -1,5 +1,5 @@
 #!perl -T
-use 5.006;
+use 5.010;
 use strict;
 use warnings;
 use Test::More;


### PR DESCRIPTION
The defined-or operator `//` was introduced in 5.010, but the heads of the files indicate you are targeting v5.006. Pick one.
